### PR TITLE
Fix GitHub icon markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -367,7 +367,6 @@
             height="50"
             viewBox="0 0 24 24"
             class="mini-link hidden"
-            add
             fill="currentColor"
           >
             <path


### PR DESCRIPTION
## Summary
- clean up stray attribute in GitHub link's SVG tag

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684392d77fe4832baf9825c2c0ba5e23